### PR TITLE
Adds missing string.h include

### DIFF
--- a/hpc/openacc/English/C/source_code/lab1/laplace2d.c
+++ b/hpc/openacc/English/C/source_code/lab1/laplace2d.c
@@ -27,6 +27,7 @@
 
 #include <math.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define OFFSET(x, y, m) (((x)*(m)) + (y))
 

--- a/hpc/openacc/English/C/source_code/lab1/solutions/laplace2d.kernels.c
+++ b/hpc/openacc/English/C/source_code/lab1/solutions/laplace2d.kernels.c
@@ -27,6 +27,7 @@
 
 #include <math.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define OFFSET(x, y, m) (((x)*(m)) + (y))
 

--- a/hpc/openacc/English/C/source_code/lab1/solutions/laplace2d.parallel.c
+++ b/hpc/openacc/English/C/source_code/lab1/solutions/laplace2d.parallel.c
@@ -27,6 +27,7 @@
 
 #include <math.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define OFFSET(x, y, m) (((x)*(m)) + (y))
 

--- a/hpc/openacc/English/C/source_code/lab2/laplace2d.c
+++ b/hpc/openacc/English/C/source_code/lab2/laplace2d.c
@@ -27,6 +27,7 @@
 
 #include <math.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define OFFSET(x, y, m) (((x)*(m)) + (y))
 

--- a/hpc/openacc/English/C/source_code/lab2/solutions/laplace2d.c
+++ b/hpc/openacc/English/C/source_code/lab2/solutions/laplace2d.c
@@ -27,6 +27,7 @@
 
 #include <math.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define OFFSET(x, y, m) (((x)*(m)) + (y))
 

--- a/hpc/openacc/English/C/source_code/lab3/laplace2d.c
+++ b/hpc/openacc/English/C/source_code/lab3/laplace2d.c
@@ -27,6 +27,7 @@
 
 #include <math.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define OFFSET(x, y, m) (((x)*(m)) + (y))
 

--- a/hpc/openacc/English/C/source_code/lab3/solutions/collapse/laplace2d.c
+++ b/hpc/openacc/English/C/source_code/lab3/solutions/collapse/laplace2d.c
@@ -27,6 +27,7 @@
 
 #include <math.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define OFFSET(x, y, m) (((x)*(m)) + (y))
 

--- a/hpc/openacc/English/C/source_code/lab3/solutions/tile/laplace2d.c
+++ b/hpc/openacc/English/C/source_code/lab3/solutions/tile/laplace2d.c
@@ -27,6 +27,7 @@
 
 #include <math.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define OFFSET(x, y, m) (((x)*(m)) + (y))
 


### PR DESCRIPTION
Hi, during the bootcamp I noticed some warnings from the compiler regarding `memset`.   Since you posted the repo I thought I would toss up a patch for that if you want it.

Cheers,
Garrett