### PR TITLE
Bugfix for stdpar

### DIFF
--- a/hpc/nways/nways_labs/nways_MD/English/C/jupyter_notebook/stdpar/nways_stdpar.ipynb
+++ b/hpc/nways/nways_labs/nways_MD/English/C/jupyter_notebook/stdpar/nways_stdpar.ipynb
@@ -160,7 +160,10 @@
    "outputs": [],
    "source": [
     "#Compile the code for muticore\n",
-    "!cd ../../source_code/stdpar && nvc++ -std=c++17 -stdpar=multicore -o rdf rdf.cpp -ltbb"
+    "!cd ../../source_code/stdpar && nvc++ -std=c++17 -stdpar=multicore \\\n",
+    "-I/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/cuda/11.2/include \\\n",
+    "-o rdf rdf.cpp -fopenmp \\\n",
+    "-L/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/cuda/11.2/lib64 -lnvToolsExt"
    ]
   },
   {
@@ -232,7 +235,7 @@
    "outputs": [],
    "source": [
     "#compile for Tesla GPU\n",
-    "!cd ../../source_code/stdpar && nvc++ -std=c++17 -DUSE_COUNTING_ITERATIOR  -stdpar=gpu -o rdf rdf.cpp "
+    "!cd ../../source_code/stdpar && nvc++ -std=c++17 -DUSE_COUNTING_ITERATOR  -stdpar=gpu -o rdf rdf.cpp "
    ]
   },
   {

--- a/hpc/nways/nways_labs/nways_MD/English/C/source_code/stdpar/rdf.cpp
+++ b/hpc/nways/nways_labs/nways_MD/English/C/source_code/stdpar/rdf.cpp
@@ -12,7 +12,7 @@
 #include <algorithm>
 #include <vector>
 #include <atomic>
-#include </opt/nvidia/hpc_sdk/Linux_x86_64/21.3/cuda/11.2/include>
+#include <nvtx3/nvToolsExt.h>
 
 //Note: The addition of execution header file
 #include <execution>


### PR DESCRIPTION
## rdf.cpp ##
1. remove incorrect include directive. It should includes a file instead of a folder.
2. add missing include header of NVTX

## nways_stdpar.ipynb ##
1. add missing include path for NVTX header and NVTX library
2. add `-fopemmp` flag due to Thrust. Otherwise, it will encounter following error:
```
"/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/cuda/11.2/include/thrust/system/omp/detail/for_each.inl", line 53: error: static assertion failed with "OpenMP compiler support is not enabled"
```
3. correct typo. It should be `-DUSE_COUNTING_ITERATOR` instead of `-DUSE_COUNTING_ITERATIOR`