### PR TITLE
Bugfix for OpenMP

### DIFF
--- a/hpc/nways/nways_labs/nways_MD/English/C/jupyter_notebook/openmp/nways_openmp.ipynb
+++ b/hpc/nways/nways_labs/nways_MD/English/C/jupyter_notebook/openmp/nways_openmp.ipynb
@@ -200,7 +200,7 @@
     "### ```teams``` directive\n",
     "```teams``` directve creates a league of thread teams where the master thread of each team executes the region. Each of these master threads executes sequentially. Or in other words teams directive spawn 1 or more thread teams with the same number of threads. The execution continues on the master threads of each team (redundantly). There is no synchronization allowed between teams. \n",
     "\n",
-    "OpenMP calls that somewhere a gang, which might be a thread on the CPU or maying a CUDA threadblock or OpenCL workgroup. It will choose how many teams to create based on where you're running, only a few on a CPU (like 1 per CPU core) or lots on a GPU (1000's possibly). ```teams``` allow OpenMP code to scale from small CPUs to large GPUs because each one works completely independently of each other ```teams```.\n",
+    "OpenACC calls that somewhere a gang, which might be a thread on the CPU or maying a CUDA threadblock or OpenCL workgroup. It will choose how many teams to create based on where you're running, only a few on a CPU (like 1 per CPU core) or lots on a GPU (1000's possibly). ```teams``` allow OpenMP code to scale from small CPUs to large GPUs because each one works completely independently of each other ```teams```.\n",
     "\n",
     "<img src=\"../images/openmp_target_teams.png\">\n",
     "\n",

--- a/hpc/nways/nways_labs/nways_MD/English/Fortran/jupyter_notebook/openmp/nways_openmp.ipynb
+++ b/hpc/nways/nways_labs/nways_MD/English/Fortran/jupyter_notebook/openmp/nways_openmp.ipynb
@@ -174,7 +174,7 @@
     "### ```teams``` directive\n",
     "```teams``` directve creates a league of thread teams where the master thread of each team executes the region. Each of these master threads executes sequentially. Or in other words teams directive spawn 1 or more thread teams with the same number of threads. The execution continues on the master threads of each team (redundantly). There is no synchronization allowed between teams. \n",
     "\n",
-    "OpenMP calls that somewhere a gang, which might be a thread on the CPU or maying a CUDA threadblock or OpenCL workgroup. It will choose how many teams to create based on where you're running, only a few on a CPU (like 1 per CPU core) or lots on a GPU (1000's possibly). ```teams``` allow OpenMP code to scale from small CPUs to large GPUs because each one works completely independently of each other ```teams```.\n",
+    "OpenACC calls that somewhere a gang, which might be a thread on the CPU or maying a CUDA threadblock or OpenCL workgroup. It will choose how many teams to create based on where you're running, only a few on a CPU (like 1 per CPU core) or lots on a GPU (1000's possibly). ```teams``` allow OpenMP code to scale from small CPUs to large GPUs because each one works completely independently of each other ```teams```.\n",
     "\n",
     "<img src=\"../images/openmp_target_teams.png\">\n",
     "\n",


### PR DESCRIPTION
The current statement - "OpenMP calls that somewhere a gang, which might be a thread on the CPU or maying a CUDA threadblock or OpenCL workgroup." is incorrect. The `gang` is an OpenACC term, not OpenMP.

I think the intention of the original statement is to refer OpenACC gang to explain what OpenMP teams is. Thus, it should be "OpenACC calls that somewhere a gang..." here.
